### PR TITLE
Add SSE consumer

### DIFF
--- a/lib/sse_consumer.ex
+++ b/lib/sse_consumer.ex
@@ -1,0 +1,160 @@
+defmodule SSEConsumer do
+  require Logger
+  use GenServer
+
+  defmodule Request do
+    @enforce_keys ~w(method url body headers)a
+    defstruct @enforce_keys
+  end
+
+  defmodule State do
+    @moduledoc false
+    @enforce_keys ~w(recipient tag request conn_id remaining_stream)a
+    defstruct @enforce_keys
+
+    def new(recipient, request = %SSEConsumer.Request{}) when is_pid(recipient) do
+      %__MODULE__{
+        recipient: recipient,
+        tag: new_tag(),
+        request: request,
+        remaining_stream: "",
+        conn_id: nil
+      }
+    end
+
+
+    def set_connection(%__MODULE__{conn_id: current_conn_id} = state, new_conn_id)
+    when new_conn_id != nil and is_nil(current_conn_id) do
+      %{state | conn_id: new_conn_id}
+    end
+
+
+    defp new_tag(), do: random_string(12)
+
+
+    defp random_string(length) do
+      :crypto.strong_rand_bytes(length) |> Base.url_encode64 |> binary_part(0, length)
+    end
+  end
+
+  #===========================================================================
+  # Public API
+  #===========================================================================
+
+  def stream_to(recipient, request, options), do: start_link(recipient, request, options)
+
+  def start_link(recipient, request = %Request{}, options) do
+    initial_state = State.new(recipient, request)
+    GenServer.start_link(__MODULE__, initial_state, options)
+  end
+
+  #===========================================================================
+  # Callbacks
+  #===========================================================================
+
+  @impl GenServer
+  def init(state) do
+    send(self(), :connect)
+    {:ok, state}
+  end
+
+
+  @impl GenServer
+  def handle_info(:connect, state = %State{}) do
+    %Request{method: method, url: url, body: body, headers: headers} = state.request
+    Logger.info("SSEConsumer connecting to TODO")
+    case HTTPoison.request(method, url, body, headers, stream_opts()) do
+      {:ok, %{id: conn_id}} ->
+        state = State.set_connection(state, conn_id)
+        receive do
+          %HTTPoison.AsyncStatus{id: ^conn_id, code: 200} ->
+            receive do
+              %HTTPoison.AsyncHeaders{id: ^conn_id, headers: _} ->
+                Logger.info("SSEConsumer connected to `#{state.source}`")
+                {:noreply, state}
+              after
+                100 ->
+                  Logger.warn("SSEConsumer timed out waiting for the headers")
+                  disconnect_and_die(state)
+            end
+          %HTTPoison.AsyncStatus{id: ^conn_id, code: 400} ->
+            receive do
+              %HTTPoison.AsyncHeaders{headers: _} ->
+                Logger.warn("SSEConsumer received HTTP 400")
+                disconnect_and_die(state)
+            end
+          after
+            2_000 ->
+              Logger.warn("SSEConsumer timed out waiting for a response")
+              disconnect_and_die(state)
+        end
+      {:error, %HTTPoison.Error{reason: reason}} ->
+        Logger.warn("SSEConsumer failed to connect. reason: `#{reason}`")
+        disconnect_and_die(state)
+    end
+  end
+
+  #---------------------------------------------------------------------------
+  # Handling HTTPoison messages
+  #---------------------------------------------------------------------------
+
+  def handle_info(%HTTPoison.AsyncChunk{chunk: ""}, %State{} = state) do
+    {:noreply, state}
+  end
+
+  def handle_info(%HTTPoison.AsyncEnd{}, %State{} = state) do
+    disconnect_and_die(state)
+  end
+
+  def handle_info(%HTTPoison.AsyncChunk{chunk: chunk}, %State{} = state) do
+    chunk = state.remaining_stream <> chunk
+    case ServerSentEvent.parse_all(chunk) do
+      {:ok, {events, remaining_stream}} ->
+        handle_events(events, state)
+        {:noreply, %{state | remaining_stream: remaining_stream}}
+      {:error, _reason} ->
+        disconnect_and_die(state)
+    end
+  end
+
+  def handle_info(%HTTPoison.Error{reason: reason}, %State{} = state) do
+    Logger.warn("SSE Consumer streaming error; #{inspect(reason)}")
+    disconnect_and_die(state)
+  end
+
+  def handle_info(info, state) do
+    # If connection is established after timeout we need to drop messages streamed to process via HTTPoison
+    Logger.warn("SSE Consumer: unexpected info message: #{inspect info}")
+    {:noreply, state}
+  end
+
+  #===========================================================================
+  # Utility functions
+  #===========================================================================
+
+  defp handle_events(events, state) do
+    # TODO chunk the events
+    message = {:sse, state.tag, events}
+    send(state.recipient, message)
+  end
+
+
+  defp stream_opts, do: [stream_to: self(), timeout: 50_000, recv_timeout: 50_000]
+
+
+  # TODO: add an optional argument of reason to be sent to the recipient
+  defp disconnect_and_die(state = %State{conn_id: conn_id}) do
+    if conn_id != nil do
+      # it shouldn't be a problem if this gets called more than once or on an invalid id
+      disconnect_httpoison(conn_id)
+    end
+    # TODO send the thing
+    {:stop, :normal, state}
+  end
+
+
+  defp disconnect_httpoison(id) do
+    :hackney.stop_async(id)
+  end
+
+end

--- a/lib/sse_consumer.ex
+++ b/lib/sse_consumer.ex
@@ -53,7 +53,7 @@ defmodule SSEConsumer do
   @impl GenServer
   def handle_info(:connect, state = %State{}) do
     %Request{method: method, url: url, body: body, headers: headers} = state.request
-    Logger.info("SSEConsumer connecting to TODO")
+    Logger.info("SSEConsumer connecting to `#{url}`")
     case HTTPoison.request(method, url, body, headers, stream_opts()) do
       {:ok, %{id: conn_id}} ->
         state = State.set_connection(state, conn_id)

--- a/lib/sse_consumer.ex
+++ b/lib/sse_consumer.ex
@@ -9,13 +9,12 @@ defmodule SSEConsumer do
 
   defmodule State do
     @moduledoc false
-    @enforce_keys ~w(recipient tag request conn_id remaining_stream)a
+    @enforce_keys ~w(recipient request conn_id remaining_stream)a
     defstruct @enforce_keys
 
     def new(recipient, request = %SSEConsumer.Request{}) when is_pid(recipient) do
       %__MODULE__{
         recipient: recipient,
-        tag: new_tag(),
         request: request,
         remaining_stream: "",
         conn_id: nil
@@ -26,14 +25,6 @@ defmodule SSEConsumer do
     def set_connection(%__MODULE__{conn_id: current_conn_id} = state, new_conn_id)
     when new_conn_id != nil and is_nil(current_conn_id) do
       %{state | conn_id: new_conn_id}
-    end
-
-
-    defp new_tag(), do: random_string(12)
-
-
-    defp random_string(length) do
-      :crypto.strong_rand_bytes(length) |> Base.url_encode64 |> binary_part(0, length)
     end
   end
 
@@ -134,7 +125,7 @@ defmodule SSEConsumer do
 
   defp handle_events(events, state) do
     # TODO chunk the events
-    message = {:sse, state.tag, events}
+    message = {:sse, events}
     send(state.recipient, message)
   end
 

--- a/lib/sse_consumer.ex
+++ b/lib/sse_consumer.ex
@@ -125,7 +125,7 @@ defmodule SSEConsumer do
 
   defp handle_events(events, state) do
     # TODO chunk the events
-    message = {:sse, events}
+    message = {:sse, self(), events}
     send(state.recipient, message)
   end
 
@@ -135,6 +135,7 @@ defmodule SSEConsumer do
 
   # TODO: add an optional argument of reason to be sent to the recipient
   defp disconnect_and_die(state = %State{conn_id: conn_id}) do
+    send(state.recipient, {:sse_disconnected, self(), :reason}) #TODO reason
     if conn_id != nil do
       # it shouldn't be a problem if this gets called more than once or on an invalid id
       disconnect_httpoison(conn_id)

--- a/lib/sse_consumer.ex
+++ b/lib/sse_consumer.ex
@@ -61,7 +61,7 @@ defmodule SSEConsumer do
           %HTTPoison.AsyncStatus{id: ^conn_id, code: 200} ->
             receive do
               %HTTPoison.AsyncHeaders{id: ^conn_id, headers: _} ->
-                Logger.info("SSEConsumer connected to `#{state.source}`")
+                Logger.info("SSEConsumer connected to `#{url}`")
                 {:noreply, state}
               after
                 100 ->
@@ -140,7 +140,6 @@ defmodule SSEConsumer do
       # it shouldn't be a problem if this gets called more than once or on an invalid id
       disconnect_httpoison(conn_id)
     end
-    # TODO send the thing
     {:stop, :normal, state}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -31,6 +31,8 @@ defmodule BackendCommon.Mixfile do
     [
       {:poison, "~> 2.0"},
       {:plug, "~> 1.3.3", only: :test},
+      {:server_sent_event, ">= 0.3.0"},
+      {:httpoison, "~> 0.11.0"},
       {:plug_logger_json, github: "paywithcurl/plug_logger_json", only: :test},
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule BackendCommon.Mixfile do
       {:poison, "~> 2.0"},
       {:plug, "~> 1.3.3", only: :test},
       {:server_sent_event, ">= 0.3.0"},
-      {:httpoison, "~> 0.11.0"},
+      {:httpoison, ">= 0.11.0"},
       {:plug_logger_json, github: "paywithcurl/plug_logger_json", only: :test},
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -29,6 +29,7 @@ defmodule BackendCommon.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
+      {:ex_doc, ">= 0.15.0", only: :dev},
       {:poison, "~> 2.0"},
       {:plug, "~> 1.3.3", only: :test},
       {:server_sent_event, ">= 0.3.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
 %{"certifi": {:hex, :certifi, "1.2.1", "c3904f192bd5284e5b13f20db3ceac9626e14eeacfbb492e19583cf0e37b22be", [], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.2", "993e0a95e9fbb790ac54ea58e700b45b299bd48bc44b4ae0404f28161f37a83e", [], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "hackney": {:hex, :hackney, "1.8.6", "21a725db3569b3fb11a6af17d5c5f654052ce9624219f1317e8639183de4a423", [], [{:certifi, "1.2.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.0.2", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "httpoison": {:hex, :httpoison, "0.11.2", "9e59f17a473ef6948f63c51db07320477bad8ba88cf1df60a3eee01150306665", [], [{:hackney, "~> 1.8.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "5.0.2", "ac203208ada855d95dc591a764b6e87259cb0e2a364218f215ad662daa8cd6b4", [], [{:unicode_util_compat, "0.2.0", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,13 @@
-%{"mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [], [], "hexpm"},
+%{"certifi": {:hex, :certifi, "1.2.1", "c3904f192bd5284e5b13f20db3ceac9626e14eeacfbb492e19583cf0e37b22be", [], [], "hexpm"},
+  "hackney": {:hex, :hackney, "1.8.6", "21a725db3569b3fb11a6af17d5c5f654052ce9624219f1317e8639183de4a423", [], [{:certifi, "1.2.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.0.2", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
+  "httpoison": {:hex, :httpoison, "0.11.2", "9e59f17a473ef6948f63c51db07320477bad8ba88cf1df60a3eee01150306665", [], [{:hackney, "~> 1.8.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
+  "idna": {:hex, :idna, "5.0.2", "ac203208ada855d95dc591a764b6e87259cb0e2a364218f215ad662daa8cd6b4", [], [{:unicode_util_compat, "0.2.0", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
+  "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [], [], "hexpm"},
+  "mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [], [], "hexpm"},
+  "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [], [], "hexpm"},
   "plug": {:hex, :plug, "1.3.6", "bcdf94ac0f4bc3b804bdbdbde37ebf598bd7ed2bfa5106ed1ab5984a09b7e75f", [], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "plug_logger_json": {:git, "https://github.com/paywithcurl/plug_logger_json.git", "988a18688360171a8bf84e446fabeda69affa5ec", []},
-  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], [], "hexpm"}}
+  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], [], "hexpm"},
+  "server_sent_event": {:hex, :server_sent_event, "0.3.0", "4352b93c10cd71f2d75e51fa4fefaa799b90299749c12bb7cd68dbea86ff957b", [], [], "hexpm"},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [], [], "hexpm"},
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.2.0", "dbbccf6781821b1c0701845eaf966c9b6d83d7c3bfc65ca2b78b88b8678bfa35", [], [], "hexpm"}}


### PR DESCRIPTION
I might add an unit test for a sanity check or to verify any properties I'm not sure about, but I think using the SSE Consumer in public-api using system tests might be guarantee enough to use it.

~WIP while I add one more feature I wanted to have - breaking down chunks of SSEs into smaller chunks.~

After thinking about it a little bit, I don't see that much value in breaking the chunks from the size they come in from the network to chunks with a max size, I'm just going to clean up the TODOs for it.