### PR TITLE
When handed a JSON encoded message, decode it

### DIFF
--- a/lib/curl/logger.ex
+++ b/lib/curl/logger.ex
@@ -12,21 +12,21 @@ defmodule Curl.Logger do
       |> Enum.map(&sanitize/1)
       |> Enum.into(%{})
       |> Map.put(:level, level)
-      |> Map.put(:message, message)
+      |> Map.put(:message, format_message(message))
       |> Map.put(:service, Application.get_env(:logger, :service, "unknown"))
       |> Poison.encode!) <> "\n"
     rescue
       error ->
         "could not format: #{inspect {level, message, metadata, error}}"
     end
-    def format(level, message, _timestamp, metadata) do
-      "could not format: #{inspect {level, message, metadata}}"
-    end
 
-    defp sanitize({k, v}) when is_pid(v) or is_port(v) or is_reference(v) do
-      {k, inspect(v)}
-    end
-    defp sanitize(x) do
-      x
-    end
+    def format(level, message, _timestamp, metadata), do: "could not format: #{inspect {level, message, metadata}}"
+
+    defp format_message(message = <<"{\"status\":">> <> _) when is_binary(message), do: Poison.decode!(message)
+
+    defp format_message(message), do: message
+
+    defp sanitize({k, v}) when is_pid(v) or is_port(v) or is_reference(v), do: {k, inspect(v)}
+
+    defp sanitize(x), do: x
   end

--- a/test/curl/logger_test.exs
+++ b/test/curl/logger_test.exs
@@ -44,9 +44,9 @@ defmodule Curl.LoggerTest do
       Logger.flush()
     end)
 
-
     assert {:ok, map1} = Poison.decode(json)
-    assert {:ok, map2} = Poison.decode(map1["message"])
+
+    map2 = map1["message"]
     assert map2["method"] == "GET"
     assert map1["module"] == "Elixir.Plug.LoggerJSON"
     Logger.configure(level: :warn)


### PR DESCRIPTION
This is a hack around how we work with `Plug.LoggerJSON`. Our Phoenix
are being JSON encoded by `Plug.LoggerJSON` and then re-encoded by our
`Curl.Logger` module.

Ideally, in future, we should rip out the various logging libraries
we're using and use a consistent logging library.